### PR TITLE
build: remove release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,38 +38,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  # Build and publish release artifacts.
-  artifact-release:
-    needs: release-plz-release
-    name: Artifact release - ${{ matrix.platform.release_for }}
-    strategy:
-      matrix:
-        platform:
-          - os_name: Linux-x86_64
-            runs-on: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
-          - os_name: Linux-aarch64
-            runs-on: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-          - os_name: macOS-aarch64
-            runs-on: macOS-latest
-            target: aarch64-apple-darwin
-          - os-name: Windows-x86_64
-            runs-on: windows-latest
-            target: x86_64-pc-windows-msvc
-    runs-on: ${{ matrix.platform.runs-on }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Build executable
-        uses: houseabsolute/actions-rust-cross@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: "--locked --release"
-          strip: true
-      - name: Publish artifacts
-        uses: houseabsolute/actions-rust-release@v0
-        with:
-          executable-name: miou
-          target: ${{ matrix.platform.target }}
-          if: matrix.toolchain == 'stable'

--- a/README.md
+++ b/README.md
@@ -150,15 +150,6 @@ services:
       - MIOU_MATRIX__PASSPHRASE=your-passphrase
 ```
 
-### Github release 
-
-You can download the latest release from the [Releases](https://github.com/florianduros/miou/releases) page.
-
-Run
-```bash
-miou --config config.yaml --data ./data
-```
-
 ### From Source
 
 Prerequisites


### PR DESCRIPTION
Currently, artifacts are failing to build due to opennssl.