### PR TITLE
fix: add user_id to alert message

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -448,7 +448,10 @@ impl Bot {
                             let _ = matrix_client
                                 .send_mention(
                                     &alert.room_id,
-                                    &Commander::get_player_turn_message(alert.player_url.clone()),
+                                    &Commander::get_player_turn_message(
+                                        alert.user_id.clone(),
+                                        alert.player_url.clone(),
+                                    ),
                                     &alert.user_id,
                                 )
                                 .await;

--- a/src/commands/commander.rs
+++ b/src/commands/commander.rs
@@ -229,6 +229,7 @@ impl Commander {
     ///
     /// # Arguments
     ///
+    /// * `user_id` - The Matrix user ID of the player
     /// * `player_url` - The URL to the player's game page
     ///
     /// # Returns
@@ -242,8 +243,8 @@ impl Commander {
     /// let message = Commander::get_player_turn_message("https://example.com/player?id=p123".to_string());
     /// assert!(message.contains("example.com"));
     /// ```
-    pub fn get_player_turn_message(player_url: String) -> String {
-        format_player_turn(player_url)
+    pub fn get_player_turn_message(user_id: String, player_url: String) -> String {
+        format_player_turn(user_id, player_url)
     }
 }
 
@@ -552,8 +553,11 @@ mod tests {
     #[test]
     fn test_get_player_turn_message() {
         assert_eq!(
-            Commander::get_player_turn_message("http://example.com/player1".to_string()),
-            "It's your turn to play: [http://example.com/player1](http://example.com/player1)."
+            Commander::get_player_turn_message(
+                "@alice:example.com".to_owned(),
+                "http://example.com/player1".to_owned()
+            ),
+            "@alice:example.com: it's your turn to play: [http://example.com/player1](http://example.com/player1)."
         )
     }
 }

--- a/src/commands/markdown_response.rs
+++ b/src/commands/markdown_response.rs
@@ -250,6 +250,7 @@ pub fn format_successful_unregister() -> String {
 ///
 /// # Arguments
 ///
+/// * `user_id` - The Matrix user ID of the player
 /// * `player_url` - The URL to the player's game page on the Terraforming Mars server
 ///
 /// # Returns
@@ -263,8 +264,11 @@ pub fn format_successful_unregister() -> String {
 /// let msg = format_player_turn("https://example.com/player?id=p123".to_string());
 /// assert!(msg.contains("turn to play"));
 /// ```
-pub fn format_player_turn(player_url: String) -> String {
-    format!("It's your turn to play: [{}]({}).", player_url, player_url)
+pub fn format_player_turn(user_id: String, player_url: String) -> String {
+    format!(
+        "{}: it's your turn to play: [{}]({}).",
+        user_id, player_url, player_url
+    )
 }
 
 /// Formats a list of registered alerts for the user.
@@ -449,8 +453,11 @@ mod tests {
     #[test]
     fn test_format_player_turn() {
         assert_eq!(
-            format_player_turn("http://example.com/player-id1".to_owned()),
-            "It's your turn to play: [http://example.com/player-id1](http://example.com/player-id1)."
+            format_player_turn(
+                "@alice:example.com".to_owned(),
+                "http://example.com/player-id1".to_owned()
+            ),
+            "@alice:example.com: it's your turn to play: [http://example.com/player-id1](http://example.com/player-id1)."
         )
     }
 }


### PR DESCRIPTION
Closes https://github.com/florianduros/miou/issues/35 

The alert message is confusing without the user_id. The other users don't know if the message is for them.