### PR TITLE
Don't erase games and alerts when terraforming mars is unavailable

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -64,7 +64,7 @@ use crate::{
     commands::{CommandContext, CommandParseError, Commander},
     config::Config,
     matrix::{MatrixClient, UserCredentials},
-    tmars::{TMarsRequester, TMarsSync},
+    tmars::{SyncError, TMarsRequester, TMarsSync},
     utils::get_path,
 };
 use std::{sync::Arc, time::Duration};
@@ -438,13 +438,21 @@ impl Bot {
                 interval.tick().await;
 
                 // Perform sync
-                // If an error occurs, log it, notify all rooms, and stop the sync task
-                if tmars_sync.lock().await.sync().await.is_err() {
-                    log::error!("stop tmars sync task due to error");
-                    matrix_client
-                        .send_to_all(&Commander::get_access_error_message())
-                        .await;
-                    break;
+                // On access errors, notify all rooms and stop the sync task.
+                // On temporary unavailability, skip this cycle and retry next interval.
+                match tmars_sync.lock().await.sync().await {
+                    Err(SyncError::AccessError) => {
+                        log::error!("stop tmars sync task due to access error");
+                        matrix_client
+                            .send_to_all(&Commander::get_access_error_message())
+                            .await;
+                        break;
+                    }
+                    Err(SyncError::Unavailable) => {
+                        log::error!("tmars server unavailable, skipping sync cycle");
+                        continue;
+                    }
+                    Ok(()) => {}
                 }
 
                 let games_map = tmars_sync.lock().await.get_games();

--- a/src/tmars/mod.rs
+++ b/src/tmars/mod.rs
@@ -41,6 +41,7 @@ pub use crate::tmars::sync::TMarsSync;
 /// # Variants
 ///
 /// * `AccessError` - Authentication or authorization failure (HTTP 401/403)
+/// * `Unavailable` - Temporary network or server error (non-auth failures)
 #[derive(Debug)]
 pub enum SyncError {
     /// Authentication or authorization failure.
@@ -48,4 +49,10 @@ pub enum SyncError {
     /// Returned when the TMars API responds with HTTP 401 (Unauthorized) or
     /// HTTP 403 (Forbidden) status codes.
     AccessError,
+    /// Temporary server or network unavailability.
+    ///
+    /// Returned when the TMars API is unreachable or returns a non-auth error.
+    /// The bot should retain existing game state and alerts until the server
+    /// becomes available again.
+    Unavailable,
 }

--- a/src/tmars/sync.rs
+++ b/src/tmars/sync.rs
@@ -180,7 +180,7 @@ impl<R: Requester> TMarsSync<R> {
                     return Err(SyncError::AccessError);
                 }
 
-                vec![]
+                return Err(SyncError::Unavailable);
             }
         };
 
@@ -793,19 +793,44 @@ mod tests {
     async fn test_pool_games_with_get_games_error() {
         let mut mock_requester = MockRequester::new();
 
-        // Mock get_games to return an error
+        // First call: populate games successfully
+        mock_requester.expect_get_games().times(1).returning(|| {
+            Ok(vec![GameResponse {
+                game_id: "game1".to_owned(),
+            }])
+        });
         mock_requester
+            .expect_get_game_details()
+            .with(mockall::predicate::eq("game1"))
+            .times(1)
+            .returning(|_| {
+                Ok(GameDetail {
+                    id: "game1".to_owned(),
+                    phase: "action".to_owned(),
+                    spectator_id: "spec1".to_owned(),
+                    players: vec![],
+                })
+            });
+
+        let mut tmars_sync = TMarsSync::new(mock_requester);
+        tmars_sync.pool_games().await.unwrap();
+        assert_eq!(tmars_sync.games.len(), 1);
+
+        // Second call: server is unavailable — existing games should be preserved
+        let mut mock_requester2 = MockRequester::new();
+        mock_requester2
             .expect_get_games()
             .times(1)
             .returning(|| Err(create_mock_error()));
+        tmars_sync.tmars_requester = mock_requester2;
 
-        let mut tmars_sync = TMarsSync::new(mock_requester);
-
-        // Call pool_games - should handle error gracefully
-        tmars_sync.pool_games().await.unwrap();
-
-        // Verify that games map is empty due to error
-        assert_eq!(tmars_sync.games.len(), 0);
+        let result = tmars_sync.pool_games().await;
+        assert!(matches!(result, Err(SyncError::Unavailable)));
+        assert_eq!(
+            tmars_sync.games.len(),
+            1,
+            "existing games must be preserved on unavailability"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Before this fix, when the server is unavailable, the local data were erased. Which is not a great behaviour in case of a network issue...